### PR TITLE
Separate PR for requirements from follow-up

### DIFF
--- a/.changeset/config.json
+++ b/.changeset/config.json
@@ -8,5 +8,6 @@
   "access": "public",
   "___experimentalUnsafeOptions_WILL_CHANGE_IN_PATCH": {
     "updateInternalDependents": "always"
-  }
+  },
+  "shouldAskForChangeTypes": true
 }

--- a/packages/cli/src/commands/add/__tests__/add.ts
+++ b/packages/cli/src/commands/add/__tests__/add.ts
@@ -46,6 +46,7 @@ const mockUserResponses = mockResponses => {
   let callCount = 0;
   let returnValues = [
     Object.keys(mockResponses.releases),
+    [],
     majorReleases,
     minorReleases
   ];

--- a/packages/cli/src/commands/add/__tests__/add.ts
+++ b/packages/cli/src/commands/add/__tests__/add.ts
@@ -46,7 +46,6 @@ const mockUserResponses = mockResponses => {
   let callCount = 0;
   let returnValues = [
     Object.keys(mockResponses.releases),
-    [],
     majorReleases,
     minorReleases
   ];
@@ -152,9 +151,6 @@ describe("Changesets", () => {
     askQuestion.mockReturnValueOnce("");
     // @ts-ignore
     askQuestionWithEditor.mockReturnValueOnce(summary);
-    const noChangeTypes: never[] = [];
-    // @ts-ignore
-    askCheckboxPlus.mockReturnValueOnce(noChangeTypes);
     // @ts-ignore
     askConfirm.mockImplementation(question => {
       question = stripAnsi(question);

--- a/packages/cli/src/commands/add/__tests__/add.ts
+++ b/packages/cli/src/commands/add/__tests__/add.ts
@@ -204,4 +204,8 @@ describe("Changesets", () => {
       })
     );
   });
+
+  // @TODO tests for the new flow with change types
+  it("should create changeset with change types per bump type", () => {});
+  it("should create changeset with change types per package", () => {});
 });

--- a/packages/cli/src/commands/add/__tests__/add.ts
+++ b/packages/cli/src/commands/add/__tests__/add.ts
@@ -152,6 +152,9 @@ describe("Changesets", () => {
     askQuestion.mockReturnValueOnce("");
     // @ts-ignore
     askQuestionWithEditor.mockReturnValueOnce(summary);
+    const noChangeTypes: never[] = [];
+    // @ts-ignore
+    askCheckboxPlus.mockReturnValueOnce(noChangeTypes);
     // @ts-ignore
     askConfirm.mockImplementation(question => {
       question = stripAnsi(question);

--- a/packages/cli/src/commands/add/changeTypeList.json
+++ b/packages/cli/src/commands/add/changeTypeList.json
@@ -1,0 +1,30 @@
+[
+    {
+      "title": "Added",
+      "text": "Added (New functionality, arg options, more UI elements)"
+    },
+    {
+      "title": "Changed",
+      "text": "Changed (Visual changes, internal changes, API changes)"
+    },
+    {
+      "title": "Removed",
+      "text": "Removed (Dead code, feature flags, consumer API's)"
+    },
+    {
+      "title": "Types",
+      "text":
+        "Types (Strictly related to the type system and should not have impact on runtime code) "
+    },
+    {
+      "title": "Documentation",
+      "text": "Documentation (README, general docs, package.json metadata)"
+    },
+    {
+      "title": "Infra",
+      "text":
+        "Infra (Tooling, performance, things that are under the hood but should have no impact if a consumer upgraded)"
+    },
+    { "title": "UX", "text": "UX (UX change)" },
+    { "title": "Misc", "text": "Misc (Anything else not noted above)" }
+]

--- a/packages/cli/src/commands/add/changeTypes.ts
+++ b/packages/cli/src/commands/add/changeTypes.ts
@@ -1,0 +1,252 @@
+import { info, log, warn } from "@changesets/logger";
+import {
+  ChangeType,
+  ChangesetWithConfirmed,
+  EmptyString,
+  Release,
+  Config
+} from "@changesets/types";
+import path from "path";
+import writeChangeset from "@changesets/write";
+import { Package } from "@manypkg/get-packages";
+import chalk from "chalk";
+import { ExternalEditor } from "external-editor";
+import spawn from "spawndamnit";
+
+import { getCommitFunctions } from "../../commit/getCommitFunctions";
+import * as cli from "../../utils/cli-utilities";
+import printConfirmationMessage from "./messages";
+import * as git from "@changesets/git";
+
+const { bold, cyan } = chalk;
+
+const allCategoriesOfChange = [
+  "Added (New functionality, arg options, more UI elements)",
+  "Changed (Visual changes, internal changes, API changes)",
+  "Removed (Dead code, feature flags, consumer API's)",
+  "Types (Strictly related to the type system and should not have impact on runtime code) ",
+  "Documentation (README, general docs, package.json metadata)",
+  "Infra (Tooling, performance, things that are under the hood but should have no impact if a consumer upgraded)",
+  "Misc (Anything else not noted above)"
+];
+export function getKindTitle(kind: string) {
+  return kind.split(" ")[0];
+}
+
+type PreviousAnswers = { [key in string]: string };
+
+export async function createChangesetWithChangeTypes(releases: Release[]) {
+  //   const changeTypeList: Array<ChangeType> = [];
+  const changesetList: Array<ChangesetWithConfirmed> = [];
+  const releaseWithChangeTypeList: Array<Release> = [];
+  let shouldAskChangeTypes = false;
+
+  const chosenChangeTypeList = await cli.askCheckboxPlus(
+    bold(`What kind of change are you making? (check all that apply)`),
+    allCategoriesOfChange.map(changeType => ({
+      name: changeType,
+      message: changeType
+    })),
+    (chosenChangeTypeList: EmptyString | string[]) => {
+      if (Array.isArray(chosenChangeTypeList)) {
+        return chosenChangeTypeList.map(x => cyan(getKindTitle(x))).join(", ");
+      }
+    }
+  );
+  shouldAskChangeTypes = chosenChangeTypeList.length > 0;
+  if (!shouldAskChangeTypes) return false;
+
+  const bumpTypes = new Set(releases.map(rel => rel.type));
+  const isSameMessageForAllPkgs = await cli.askConfirm(
+    "Would you like to reuse the same message for all packages of this bump type?"
+  );
+
+  if (isSameMessageForAllPkgs) {
+    for (const bumpType of bumpTypes) {
+      const changeTypeList: Array<ChangeType> = [];
+      const pkgsForThisBumpType = releases
+        .filter(rel => rel.type === bumpType)
+        .map(rel => rel.name)
+        .join(", ");
+
+      log(chalk.yellow(`${bumpType} :`), chalk.cyan(pkgsForThisBumpType));
+
+      for (const category of chosenChangeTypeList) {
+        const description = await cli.askQuestion(
+          `[ ${getKindTitle(category)} ]`
+        );
+        changeTypeList.push({ description, category });
+      }
+
+      const releasesWithChangeTypes = releases
+        .filter(rel => rel.type === bumpType)
+        .map(rel => ({ ...rel, changeTypes: changeTypeList }));
+
+      releaseWithChangeTypeList.push(...releasesWithChangeTypes);
+    }
+    changesetList.push({
+      releases: releaseWithChangeTypeList,
+      confirmed: false,
+      summary: ""
+    });
+  } else {
+    const previousAnswers: PreviousAnswers = {};
+    for (const release of releases) {
+      log(chalk.yellow(`${release.type} :`), chalk.cyan(release.name));
+      const currChangesetChangeTypeList: ChangeType[] = [];
+
+      for (const category of chosenChangeTypeList) {
+        const description = await getDescription(previousAnswers, category);
+        currChangesetChangeTypeList.push({
+          description,
+          category
+        });
+      }
+      const releaseWithChangeTypeList = [
+        { ...release, changeTypes: currChangesetChangeTypeList }
+      ];
+      changesetList.push({
+        confirmed: false,
+        summary: "",
+        releases: releaseWithChangeTypeList
+      });
+    }
+  }
+
+  for (let changeset of changesetList) {
+    await setSummary(changeset);
+  }
+}
+type WriteChangesetListArgs = {
+  changesets: ChangesetWithConfirmed[];
+  packages: Package[];
+  cwd: string;
+  changesetBase: string;
+  empty?: boolean;
+  config: Config;
+  open?: boolean;
+};
+export async function writeChangesetList({
+  changesets,
+  packages,
+  cwd,
+  changesetBase,
+  empty,
+  config,
+  open
+}: WriteChangesetListArgs) {
+  for (let changeset of changesets) {
+    printConfirmationMessage(changeset, packages.length > 1);
+
+    if (!changeset.confirmed) {
+      changeset = {
+        ...changeset,
+        confirmed: await cli.askConfirm("Is this your desired changeset?")
+      };
+    }
+
+    if (!changeset.confirmed) continue;
+
+    const changesetID = await writeChangeset(changeset, cwd);
+    const [{ getAddMessage }, commitOpts] = getCommitFunctions(
+      config.commit,
+      cwd
+    );
+    if (getAddMessage) {
+      await git.add(path.resolve(changesetBase, `${changesetID}.md`), cwd);
+      await git.commit(await getAddMessage(changeset, commitOpts), cwd);
+      log(chalk.green(`${empty ? "Empty " : ""}Changeset added and committed`));
+    } else {
+      log(
+        chalk.green(
+          `${empty ? "Empty " : ""}Changeset added! - you can now commit it\n`
+        )
+      );
+    }
+
+    let hasMajorChange = [...changeset.releases].find(c => c.type === "major");
+
+    if (hasMajorChange) {
+      warn(
+        "This Changeset includes a major change and we STRONGLY recommend adding more information to the changeset:"
+      );
+      warn("WHAT the breaking change is");
+      warn("WHY the change was made");
+      warn("HOW a consumer should update their code");
+    } else {
+      log(
+        chalk.green(
+          "If you want to modify or expand on the changeset summary, you can find it here"
+        )
+      );
+    }
+
+    const changesetPath = path.resolve(changesetBase, `${changesetID}.md`);
+    info(chalk.blue(changesetPath));
+
+    if (open) {
+      // this is really a hack to reuse the logic embedded in `external-editor` related to determining the editor
+      const externalEditor = new ExternalEditor();
+      externalEditor.cleanup();
+      spawn(
+        externalEditor.editor.bin,
+        externalEditor.editor.args.concat([changesetPath]),
+        {
+          detached: true,
+          stdio: "inherit"
+        }
+      );
+    }
+  }
+}
+
+async function getDescription(
+  previousAnswers: PreviousAnswers,
+  category: string
+) {
+  const previousAnswer = previousAnswers[category];
+  const question = `Do you want to reuse your previous answer for the current package? (${previousAnswer})`;
+  if (previousAnswer) {
+    const shouldReusePreviousAnswer = await cli.askConfirm(question);
+    if (shouldReusePreviousAnswer) return previousAnswer;
+  }
+
+  const description = await cli.askQuestion(`[ ${getKindTitle(category)} ]`);
+  previousAnswers[category] = description;
+  return description;
+}
+
+async function setSummary(changeSet: ChangesetWithConfirmed) {
+  log(
+    "Please enter a summary for this change (this will be in the changelogs)."
+  );
+  log(chalk.gray("  (submit empty line to open external editor)"));
+
+  let summary = await cli.askQuestion("Summary");
+  if (summary.length === 0) {
+    try {
+      summary = cli.askQuestionWithEditor(
+        "\n\n# Please enter a summary for your changes.\n# An empty message aborts the editor."
+      );
+      if (summary.length > 0) {
+        changeSet.summary = summary;
+        changeSet.confirmed = true;
+        return;
+      }
+    } catch (err) {
+      log(
+        "An error happened using external editor. Please type your summary here:"
+      );
+    }
+
+    summary = await cli.askQuestion("");
+    while (summary.length === 0) {
+      summary = await cli.askQuestion(
+        "\n\n# A summary is required for the changelog! 😪"
+      );
+    }
+  }
+
+  changeSet.summary = summary;
+  changeSet.confirmed = false;
+}

--- a/packages/cli/src/commands/add/changeTypes.ts
+++ b/packages/cli/src/commands/add/changeTypes.ts
@@ -1,22 +1,15 @@
-import { info, log } from "@changesets/logger";
+import { log } from "@changesets/logger";
 import {
   ChangeType,
   ChangesetWithConfirmed,
   EmptyString,
   Release,
   Config,
-  VersionType,
-  Changeset
+  VersionType
 } from "@changesets/types";
-import path from "path";
-import { Package } from "@manypkg/get-packages";
 import chalk from "chalk";
 
-import { getCommitFunctions } from "../../commit/getCommitFunctions";
 import * as cli from "../../utils/cli-utilities";
-import printConfirmationMessage from "./messages";
-import * as git from "@changesets/git";
-import { determineEditorHack, warnIfMajor } from ".";
 import changeTypeList from "./changeTypeList.json";
 
 const { bold, cyan } = chalk;
@@ -25,7 +18,6 @@ type ChangeTypeOption = { title: string; text: string };
 const allChangeTypes: ChangeTypeOption[] = changeTypeList;
 
 type PreviousAnswers = { [key in string]: string };
-
 export class ChangesetsWithChangeTypes {
   private config: Config;
   private isWithChangeTypes: boolean = false;
@@ -191,65 +183,6 @@ async function getReleasesPerPackage(
   return changesetList;
 }
 
-type WriteChangesetListArgs = {
-  changesets: ChangesetWithConfirmed[];
-  packages: Package[];
-  cwd: string;
-  changesetBase: string;
-  empty?: boolean;
-  config: Config;
-  open?: boolean;
-  writeChangeset: (changeset: Changeset, cwd: string) => Promise<string>;
-};
-export async function writeChangesetList({
-  changesets,
-  packages,
-  cwd,
-  changesetBase,
-  empty,
-  config,
-  open,
-  writeChangeset
-}: WriteChangesetListArgs) {
-  for (let changeset of changesets) {
-    printConfirmationMessage(changeset, packages.length > 1);
-
-    if (!changeset.confirmed) {
-      changeset = {
-        ...changeset,
-        confirmed: await cli.askConfirm("Is this your desired changeset?")
-      };
-    }
-
-    if (!changeset.confirmed) continue;
-
-    const changesetID = await writeChangeset(changeset, cwd);
-
-    const [{ getAddMessage }, commitOpts] = getCommitFunctions(
-      config.commit,
-      cwd
-    );
-    if (getAddMessage) {
-      await git.add(path.resolve(changesetBase, `${changesetID}.md`), cwd);
-      await git.commit(await getAddMessage(changeset, commitOpts), cwd);
-      log(chalk.green(`${empty ? "Empty " : ""}Changeset added and committed`));
-    } else {
-      log(
-        chalk.green(
-          `${empty ? "Empty " : ""}Changeset added! - you can now commit it\n`
-        )
-      );
-    }
-
-    warnIfMajor(changeset);
-
-    const changesetPath = path.resolve(changesetBase, `${changesetID}.md`);
-    info(chalk.blue(changesetPath));
-
-    if (open) determineEditorHack(changesetPath);
-  }
-}
-
 async function getDescriptionWithPreviousAnswer(
   previousAnswers: PreviousAnswers,
   category: ChangeTypeOption
@@ -266,6 +199,7 @@ async function getDescriptionWithPreviousAnswer(
   return description;
 }
 
+// @TODO merge duplicate setSummary with existing
 async function setSummary(changeSet: ChangesetWithConfirmed, config: Config) {
   log(
     "Please enter a summary for this change (this will be in the changelogs)."
@@ -299,71 +233,4 @@ async function setSummary(changeSet: ChangesetWithConfirmed, config: Config) {
 
   changeSet.summary = summary;
   changeSet.confirmed = false;
-}
-
-function groupByBumpType(releases: Release[]) {
-  const major: Release[] = [];
-  const minor: Release[] = [];
-  const patch: Release[] = [];
-  const none: Release[] = [];
-
-  releases.forEach(rel => {
-    if (rel.type === "major") major.push(rel);
-    else if (rel.type === "minor") minor.push(rel);
-    else if (rel.type === "patch") patch.push(rel);
-    else major.push(rel);
-  });
-  return { major, minor, patch, none };
-}
-function getReleasesSection(releases: Release[]) {
-  return `---
-${releases.map(release => `"${release.name}": ${release.type}`).join("\n")}
----\n`;
-}
-function getChangeTypesSection(releases: Release[], bumpType?: VersionType) {
-  let changeTypes: ChangeType[] = [];
-
-  if (bumpType) {
-    const [oneRelease] = releases.filter(({ type }) => type === bumpType);
-    if (!oneRelease?.changeTypes) changeTypes = [];
-    else changeTypes = oneRelease.changeTypes;
-  } else {
-    changeTypes = releases.flatMap(rel => rel.changeTypes || []);
-  }
-
-  return `${changeTypes
-    .filter(chk => chk.description)
-    .map(chk => `- [ ${chk.category.title} ] ${chk.description}`)
-    .join("\n")}\n`;
-}
-
-export function getChangesetContent(
-  releases: Release[],
-  summary: string,
-  splitReleasesByBumpType = false
-) {
-  if (splitReleasesByBumpType && releases.some(rel => rel.changeTypes)) {
-    const grouped = Object.entries(groupByBumpType(releases)).filter(
-      ([, releases]) => releases.length
-    ) as [VersionType, Release[]][];
-
-    return `${grouped
-      .map(
-        ([bumpType, releases]) =>
-          `${getReleasesSection(releases)}
-${getChangeTypesSection(releases, bumpType)}`
-      )
-      .join("\n")}
-
-${summary}
-`;
-  }
-
-  if (releases.some(rel => rel.changeTypes))
-    return `${getReleasesSection(releases)} 
-  ${getChangeTypesSection(releases)}
-
-${summary}
-`;
-  return null;
 }

--- a/packages/cli/src/commands/add/changeTypes.ts
+++ b/packages/cli/src/commands/add/changeTypes.ts
@@ -50,6 +50,7 @@ export class ChangesetsWithChangeTypes {
   }
 
   async setChangeTypeList() {
+    if (!this.config.shouldAskForChangeTypes) return;
     const chosenChangeTypeList = await getChangeTypeList();
     this.chosenChangeTypeList = chosenChangeTypeList;
     this.isWithChangeTypes = chosenChangeTypeList?.length > 0;

--- a/packages/cli/src/commands/add/changeTypes.ts
+++ b/packages/cli/src/commands/add/changeTypes.ts
@@ -366,12 +366,18 @@ ${releases.map(release => `"${release.name}": ${release.type}`).join("\n")}
 ---\n`;
 }
 function getChangeTypesSection(releases: Release[], bumpType?: VersionType) {
-  const filteredReleases = bumpType
-    ? releases.filter(({ type }) => type === bumpType)
-    : releases;
+  let changeTypes: ChangeType[] = [];
 
-  return `${filteredReleases
-    .flatMap(rel => rel.changeTypes || [])
+  if (bumpType) {
+    const [oneRelease] = releases.filter(({ type }) => type === bumpType);
+    if (!oneRelease?.changeTypes) changeTypes = [];
+    else changeTypes = oneRelease.changeTypes;
+  } else {
+    changeTypes = releases.flatMap(rel => rel.changeTypes || []);
+  }
+
+  return `${changeTypes
+    .filter(chk => chk.description)
     .map(chk => `- [ ${getKindTitle(chk.category)} ] ${chk.description}`)
     .join("\n")}\n`;
 }

--- a/packages/cli/src/commands/add/changeTypes.ts
+++ b/packages/cli/src/commands/add/changeTypes.ts
@@ -46,7 +46,7 @@ export async function useCreateChangesetsWithChangeTypes() {
   return {
     setChangeTypeList: async () => {
       chosenChangeTypeList = await getChangeTypeList();
-      isWithChangeTypes = chosenChangeTypeList.length > 0;
+      isWithChangeTypes = chosenChangeTypeList?.length > 0;
     },
     setReleases: async (newReleases: Release[]) => {
       if (!isWithChangeTypes) return;

--- a/packages/cli/src/commands/add/changeTypes.ts
+++ b/packages/cli/src/commands/add/changeTypes.ts
@@ -37,43 +37,63 @@ export function getKindTitle(kind: string) {
 
 type PreviousAnswers = { [key in string]: string };
 
-export async function useCreateChangesetsWithChangeTypes() {
-  let isWithChangeTypes: boolean = false;
-  let releases: Release[] = [];
-  let chosenChangeTypeList: string[] = [];
-  let changesetList: ChangesetWithConfirmed[] = [];
+// function WithChangeTypes(
+//   target: any,
+//   propertyName: string,
+//   descriptor: TypedPropertyDescriptor<any>
+// ) {
+//   let method = descriptor.value!;
 
-  return {
-    setChangeTypeList: async () => {
-      chosenChangeTypeList = await getChangeTypeList();
-      isWithChangeTypes = chosenChangeTypeList?.length > 0;
-    },
-    setReleases: async (newReleases: Release[]) => {
-      if (!isWithChangeTypes) return;
-      releases = newReleases;
-    },
-    setChangesetList: async () => {
-      if (!isWithChangeTypes) return;
-      if (!releases.length || !chosenChangeTypeList.length)
-        throw new Error("releases and chosenChangeTypeList must be set");
+//   descriptor.value = function() {
+//     if (!target.isWithChangeTypes) return null;
+//   };
+//   return method.apply(this, arguments);
+// }
 
-      changesetList = await getChangesetList(releases, chosenChangeTypeList);
-    },
-    setSummaries: async () => {
-      if (!isWithChangeTypes) return;
-      if (!changesetList.length)
-        throw new Error("releases and chosenChangeTypeList must be set");
+export class ChangesetsWithChangeTypes {
+  private isWithChangeTypes: boolean = false;
+  private releases: Release[] = [];
+  private chosenChangeTypeList: string[] = [];
+  private changesetList: ChangesetWithConfirmed[] = [];
 
-      for (let changeset of changesetList) await setSummary(changeset);
-    },
-    getFinalChangesetList: async () => {
-      if (!isWithChangeTypes) return;
-      if (!changesetList.length)
-        throw new Error("releases and chosenChangeTypeList must be set");
+  async setChangeTypeList() {
+    const chosenChangeTypeList = await getChangeTypeList();
+    this.chosenChangeTypeList = chosenChangeTypeList;
+    this.isWithChangeTypes = chosenChangeTypeList?.length > 0;
+  }
 
-      return changesetList;
-    }
-  };
+  async setReleases(newReleases: Release[]) {
+    if (!this.isWithChangeTypes) return;
+    this.releases = newReleases;
+  }
+
+  async setChangesetList() {
+    if (!this.isWithChangeTypes) return;
+    if (!this.releases.length || !this.chosenChangeTypeList.length)
+      throw new Error("releases and chosenChangeTypeList must be set");
+
+    this.changesetList = await getChangesetList(
+      this.releases,
+      this.chosenChangeTypeList
+    );
+  }
+
+  // @WithChangeTypes
+  async setSummaries() {
+    if (!this.isWithChangeTypes) return;
+    if (!this.changesetList.length)
+      throw new Error("changesetList must be set");
+
+    for (let changeset of this.changesetList) await setSummary(changeset);
+  }
+
+  async getFinalChangesetList() {
+    if (!this.isWithChangeTypes) return;
+    if (!this.changesetList.length)
+      throw new Error("changesetList must be set");
+
+    return this.changesetList;
+  }
 }
 
 async function getChangeTypeList() {

--- a/packages/cli/src/commands/add/changeTypes.ts
+++ b/packages/cli/src/commands/add/changeTypes.ts
@@ -29,6 +29,7 @@ const allCategoriesOfChange = [
   "Types (Strictly related to the type system and should not have impact on runtime code) ",
   "Documentation (README, general docs, package.json metadata)",
   "Infra (Tooling, performance, things that are under the hood but should have no impact if a consumer upgraded)",
+  "UX (UX change)",
   "Misc (Anything else not noted above)"
 ];
 export function getKindTitle(kind: string) {

--- a/packages/cli/src/commands/add/createChangeset.ts
+++ b/packages/cli/src/commands/add/createChangeset.ts
@@ -7,7 +7,8 @@ import { error, log } from "@changesets/logger";
 import {
   Release,
   PackageJSON,
-  ChangesetWithConfirmed
+  ChangesetWithConfirmed,
+  Config
 } from "@changesets/types";
 import { Package } from "@manypkg/get-packages";
 import { ExitError } from "@changesets/errors";
@@ -103,10 +104,11 @@ function formatPkgNameAndVersion(pkgName: string, version: string) {
 
 export default async function createChangeset(
   changedPackages: Array<string>,
-  allPackages: Package[]
+  allPackages: Package[],
+  config: Config
 ): Promise<ChangesetWithConfirmed | Array<ChangesetWithConfirmed>> {
   const releases: Array<Release> = [];
-  const changeset = new ChangesetsWithChangeTypes();
+  const changeset = new ChangesetsWithChangeTypes(config);
 
   if (allPackages.length > 1) {
     const packagesToRelease = await getPackagesToRelease(
@@ -248,7 +250,7 @@ export default async function createChangeset(
   );
   log(chalk.gray("  (submit empty line to open external editor)"));
 
-  let summary = await cli.askQuestion("Summary");
+  let summary = config.alwaysOpenEditor ? "" : await cli.askQuestion("Summary");
   if (summary.length === 0) {
     try {
       summary = cli.askQuestionWithEditor(

--- a/packages/cli/src/commands/add/createChangeset.ts
+++ b/packages/cli/src/commands/add/createChangeset.ts
@@ -4,9 +4,14 @@ import semver from "semver";
 
 import * as cli from "../../utils/cli-utilities";
 import { error, log } from "@changesets/logger";
-import { Release, PackageJSON } from "@changesets/types";
+import {
+  Release,
+  PackageJSON,
+  ChangesetWithConfirmed
+} from "@changesets/types";
 import { Package } from "@manypkg/get-packages";
 import { ExitError } from "@changesets/errors";
+import { createChangesetWithChangeTypes } from "./changeTypes";
 
 const { green, yellow, red, bold, blue, cyan } = chalk;
 
@@ -99,7 +104,7 @@ function formatPkgNameAndVersion(pkgName: string, version: string) {
 export default async function createChangeset(
   changedPackages: Array<string>,
   allPackages: Package[]
-): Promise<{ confirmed: boolean; summary: string; releases: Array<Release> }> {
+): Promise<ChangesetWithConfirmed | Array<ChangesetWithConfirmed>> {
   const releases: Array<Release> = [];
 
   if (allPackages.length > 1) {
@@ -113,6 +118,9 @@ export default async function createChangeset(
     );
 
     let pkgsLeftToGetBumpTypeFor = new Set(packagesToRelease);
+
+    const createdChangesets = await createChangesetWithChangeTypes(releases);
+    if (createdChangesets) return createdChangesets;
 
     let pkgsThatShouldBeMajorBumped = (
       await cli.askCheckboxPlus(

--- a/packages/cli/src/commands/add/createChangeset.ts
+++ b/packages/cli/src/commands/add/createChangeset.ts
@@ -11,7 +11,7 @@ import {
 } from "@changesets/types";
 import { Package } from "@manypkg/get-packages";
 import { ExitError } from "@changesets/errors";
-import { useCreateChangesetsWithChangeTypes } from "./changeTypes";
+import { ChangesetsWithChangeTypes } from "./changeTypes";
 
 const { green, yellow, red, bold, blue, cyan } = chalk;
 
@@ -106,13 +106,7 @@ export default async function createChangeset(
   allPackages: Package[]
 ): Promise<ChangesetWithConfirmed | Array<ChangesetWithConfirmed>> {
   const releases: Array<Release> = [];
-  const {
-    setChangeTypeList,
-    setReleases,
-    setChangesetList,
-    setSummaries,
-    getFinalChangesetList
-  } = await useCreateChangesetsWithChangeTypes();
+  const changeset = new ChangesetsWithChangeTypes();
 
   if (allPackages.length > 1) {
     const packagesToRelease = await getPackagesToRelease(
@@ -126,7 +120,7 @@ export default async function createChangeset(
 
     let pkgsLeftToGetBumpTypeFor = new Set(packagesToRelease);
 
-    await setChangeTypeList();
+    await changeset.setChangeTypeList();
 
     let pkgsThatShouldBeMajorBumped = (
       await cli.askCheckboxPlus(
@@ -227,7 +221,7 @@ export default async function createChangeset(
   } else {
     let pkg = allPackages[0];
 
-    await setChangeTypeList();
+    await changeset.setChangeTypeList();
 
     let type = await cli.askList(
       `What kind of change is this for ${green(
@@ -243,10 +237,10 @@ export default async function createChangeset(
     }
     releases.push({ name: pkg.packageJson.name, type });
   }
-  await setReleases(releases);
-  await setChangesetList();
-  await setSummaries();
-  const changesets = await getFinalChangesetList();
+  await changeset.setReleases(releases);
+  await changeset.setChangesetList();
+  await changeset.setSummaries();
+  const changesets = await changeset.getFinalChangesetList();
   if (changesets?.length) return changesets;
 
   log(

--- a/packages/cli/src/commands/add/createChangeset.ts
+++ b/packages/cli/src/commands/add/createChangeset.ts
@@ -11,7 +11,7 @@ import {
 } from "@changesets/types";
 import { Package } from "@manypkg/get-packages";
 import { ExitError } from "@changesets/errors";
-import { createChangesetWithChangeTypes } from "./changeTypes";
+import { createChangesetsWithChangeTypes } from "./changeTypes";
 
 const { green, yellow, red, bold, blue, cyan } = chalk;
 
@@ -119,7 +119,9 @@ export default async function createChangeset(
 
     let pkgsLeftToGetBumpTypeFor = new Set(packagesToRelease);
 
-    const createdChangesets = await createChangesetWithChangeTypes(releases);
+    const createdChangesets = await createChangesetsWithChangeTypes(
+      pkgsLeftToGetBumpTypeFor
+    );
     if (createdChangesets) return createdChangesets;
 
     let pkgsThatShouldBeMajorBumped = (
@@ -220,6 +222,10 @@ export default async function createChangeset(
     }
   } else {
     let pkg = allPackages[0];
+
+    const createdChangesets = await createChangesetsWithChangeTypes();
+    if (createdChangesets) return createdChangesets;
+
     let type = await cli.askList(
       `What kind of change is this for ${green(
         pkg.packageJson.name

--- a/packages/cli/src/commands/add/index.ts
+++ b/packages/cli/src/commands/add/index.ts
@@ -13,6 +13,7 @@ import { getCommitFunctions } from "../../commit/getCommitFunctions";
 import createChangeset from "./createChangeset";
 import printConfirmationMessage from "./messages";
 import { ExternalEditor } from "external-editor";
+import { writeChangesetList } from "./changeTypes";
 
 type UnwrapPromise<T extends Promise<any>> = T extends Promise<infer R>
   ? R
@@ -42,6 +43,21 @@ export default async function add(
       .filter(a => a)
       .map(pkg => pkg.packageJson.name);
     newChangeset = await createChangeset(changePackagesName, packages.packages);
+
+    if (Array.isArray(newChangeset)) {
+      const functionArguments = {
+        cwd,
+        changesetBase,
+        empty,
+        config,
+        open,
+        packages: packages.packages,
+        changesets: newChangeset
+      };
+      await writeChangesetList(functionArguments);
+      return;
+    }
+
     printConfirmationMessage(newChangeset, packages.packages.length > 1);
 
     if (!newChangeset.confirmed) {

--- a/packages/cli/src/commands/add/index.ts
+++ b/packages/cli/src/commands/add/index.ts
@@ -52,7 +52,8 @@ export default async function add(
         config,
         open,
         packages: packages.packages,
-        changesets: newChangeset
+        changesets: newChangeset,
+        writeChangeset
       };
       await writeChangesetList(functionArguments);
       return;

--- a/packages/cli/src/commands/add/index.ts
+++ b/packages/cli/src/commands/add/index.ts
@@ -42,7 +42,11 @@ export default async function add(
     const changePackagesName = changedPackages
       .filter(a => a)
       .map(pkg => pkg.packageJson.name);
-    newChangeset = await createChangeset(changePackagesName, packages.packages);
+    newChangeset = await createChangeset(
+      changePackagesName,
+      packages.packages,
+      config
+    );
 
     if (Array.isArray(newChangeset)) {
       const functionArguments = {

--- a/packages/cli/src/commands/add/writeChangeTypes.ts
+++ b/packages/cli/src/commands/add/writeChangeTypes.ts
@@ -1,0 +1,146 @@
+import { info, log } from "@changesets/logger";
+import {
+  ChangeType,
+  ChangesetWithConfirmed,
+  Release,
+  Config,
+  VersionType,
+  Changeset
+} from "@changesets/types";
+import path from "path";
+import { Package } from "@manypkg/get-packages";
+import chalk from "chalk";
+
+import { getCommitFunctions } from "../../commit/getCommitFunctions";
+import * as cli from "../../utils/cli-utilities";
+import printConfirmationMessage from "./messages";
+import * as git from "@changesets/git";
+import { determineEditorHack, warnIfMajor } from ".";
+
+type WriteChangesetListArgs = {
+  changesets: ChangesetWithConfirmed[];
+  packages: Package[];
+  cwd: string;
+  changesetBase: string;
+  empty?: boolean;
+  config: Config;
+  open?: boolean;
+  // @TODO fix bug where can't import writeChangeset from "@changesets/write"
+  writeChangeset: (changeset: Changeset, cwd: string) => Promise<string>;
+};
+export async function writeChangesetList({
+  changesets,
+  packages,
+  cwd,
+  changesetBase,
+  empty,
+  config,
+  open,
+  writeChangeset
+}: WriteChangesetListArgs) {
+  // @TODO refactor current flow to use it here and reduce duplicate code
+  for (let changeset of changesets) {
+    printConfirmationMessage(changeset, packages.length > 1);
+
+    if (!changeset.confirmed) {
+      changeset = {
+        ...changeset,
+        confirmed: await cli.askConfirm("Is this your desired changeset?")
+      };
+    }
+
+    if (!changeset.confirmed) continue;
+
+    const changesetID = await writeChangeset(changeset, cwd);
+
+    const [{ getAddMessage }, commitOpts] = getCommitFunctions(
+      config.commit,
+      cwd
+    );
+    if (getAddMessage) {
+      await git.add(path.resolve(changesetBase, `${changesetID}.md`), cwd);
+      await git.commit(await getAddMessage(changeset, commitOpts), cwd);
+      log(chalk.green(`${empty ? "Empty " : ""}Changeset added and committed`));
+    } else {
+      log(
+        chalk.green(
+          `${empty ? "Empty " : ""}Changeset added! - you can now commit it\n`
+        )
+      );
+    }
+
+    warnIfMajor(changeset);
+
+    const changesetPath = path.resolve(changesetBase, `${changesetID}.md`);
+    info(chalk.blue(changesetPath));
+
+    if (open) determineEditorHack(changesetPath);
+  }
+}
+
+function groupByBumpType(releases: Release[]) {
+  const major: Release[] = [];
+  const minor: Release[] = [];
+  const patch: Release[] = [];
+  const none: Release[] = [];
+
+  releases.forEach(rel => {
+    if (rel.type === "major") major.push(rel);
+    else if (rel.type === "minor") minor.push(rel);
+    else if (rel.type === "patch") patch.push(rel);
+    else major.push(rel);
+  });
+  return { major, minor, patch, none };
+}
+function getReleasesSection(releases: Release[]) {
+  return `---
+  ${releases.map(release => `"${release.name}": ${release.type}`).join("\n")}
+  ---\n`;
+}
+function getChangeTypesSection(releases: Release[], bumpType?: VersionType) {
+  let changeTypes: ChangeType[] = [];
+
+  if (bumpType) {
+    const [oneRelease] = releases.filter(({ type }) => type === bumpType);
+    if (!oneRelease?.changeTypes) changeTypes = [];
+    else changeTypes = oneRelease.changeTypes;
+  } else {
+    changeTypes = releases.flatMap(rel => rel.changeTypes || []);
+  }
+
+  return `${changeTypes
+    .filter(chk => chk.description)
+    .map(chk => `- [ ${chk.category.title} ] ${chk.description}`)
+    .join("\n")}\n`;
+}
+
+export function getChangesetContent(
+  releases: Release[],
+  summary: string,
+  splitReleasesByBumpType = false
+) {
+  if (splitReleasesByBumpType && releases.some(rel => rel.changeTypes)) {
+    const grouped = Object.entries(groupByBumpType(releases)).filter(
+      ([, releases]) => releases.length
+    ) as [VersionType, Release[]][];
+
+    return `${grouped
+      .map(
+        ([bumpType, releases]) =>
+          `${getReleasesSection(releases)}
+  ${getChangeTypesSection(releases, bumpType)}`
+      )
+      .join("\n")}
+  
+  ${summary}
+  `;
+  }
+
+  if (releases.some(rel => rel.changeTypes))
+    return `${getReleasesSection(releases)} 
+    ${getChangeTypesSection(releases)}
+  
+  ${summary}
+  `;
+  return null;
+}

--- a/packages/config/src/index.test.ts
+++ b/packages/config/src/index.test.ts
@@ -42,6 +42,8 @@ test("read reads the config", async () => {
     commit: ["@changesets/cli/commit", { skipCI: "version" }],
     access: "restricted",
     baseBranch: "master",
+    alwaysOpenEditor: false,
+    shouldAskForChangeTypes: false,
     updateInternalDependencies: "patch",
     ignore: [],
     bumpVersionsWithWorkspaceProtocolOnly: false,
@@ -60,6 +62,8 @@ let defaults = {
   commit: false,
   access: "restricted",
   baseBranch: "master",
+  alwaysOpenEditor: false,
+  shouldAskForChangeTypes: false,
   updateInternalDependencies: "patch",
   ignore: [],
   ___experimentalUnsafeOptions_WILL_CHANGE_IN_PATCH: {

--- a/packages/config/src/index.ts
+++ b/packages/config/src/index.ts
@@ -22,7 +22,7 @@ export let defaultWrittenConfig = {
   linked: [] as Linked,
   access: "restricted",
   baseBranch: "master",
-  alwaysOpenEditor: true,
+  alwaysOpenEditor: false,
   updateInternalDependencies: "patch",
   ignore: [] as ReadonlyArray<string>
 } as const;
@@ -387,7 +387,9 @@ export let parse = (json: WrittenConfig, packages: Packages): Config => {
         : json.baseBranch,
 
     alwaysOpenEditor:
-      json.alwaysOpenEditor === undefined ? false : json.alwaysOpenEditor,
+      json.alwaysOpenEditor === undefined
+        ? defaultWrittenConfig.alwaysOpenEditor
+        : json.alwaysOpenEditor,
 
     updateInternalDependencies:
       json.updateInternalDependencies === undefined

--- a/packages/config/src/index.ts
+++ b/packages/config/src/index.ts
@@ -23,6 +23,7 @@ export let defaultWrittenConfig = {
   access: "restricted",
   baseBranch: "master",
   alwaysOpenEditor: false,
+  shouldAskForChangeTypes: false,
   updateInternalDependencies: "patch",
   ignore: [] as ReadonlyArray<string>
 } as const;
@@ -390,6 +391,11 @@ export let parse = (json: WrittenConfig, packages: Packages): Config => {
       json.alwaysOpenEditor === undefined
         ? defaultWrittenConfig.alwaysOpenEditor
         : json.alwaysOpenEditor,
+
+    shouldAskForChangeTypes:
+      json.shouldAskForChangeTypes === undefined
+        ? defaultWrittenConfig.shouldAskForChangeTypes
+        : json.shouldAskForChangeTypes,
 
     updateInternalDependencies:
       json.updateInternalDependencies === undefined

--- a/packages/config/src/index.ts
+++ b/packages/config/src/index.ts
@@ -22,6 +22,7 @@ export let defaultWrittenConfig = {
   linked: [] as Linked,
   access: "restricted",
   baseBranch: "master",
+  alwaysOpenEditor: true,
   updateInternalDependencies: "patch",
   ignore: [] as ReadonlyArray<string>
 } as const;
@@ -384,6 +385,9 @@ export let parse = (json: WrittenConfig, packages: Packages): Config => {
       json.baseBranch === undefined
         ? defaultWrittenConfig.baseBranch
         : json.baseBranch,
+
+    alwaysOpenEditor:
+      json.alwaysOpenEditor === undefined ? false : json.alwaysOpenEditor,
 
     updateInternalDependencies:
       json.updateInternalDependencies === undefined

--- a/packages/types/src/index.ts
+++ b/packages/types/src/index.ts
@@ -36,8 +36,10 @@ export type Changeset = {
 
 export type EmptyString = ``;
 
+type ChangeTypeOption = { title: string; text: string };
+
 export type ChangeType = {
-  category: string;
+  category: ChangeTypeOption;
   description: string;
 };
 

--- a/packages/types/src/index.ts
+++ b/packages/types/src/index.ts
@@ -83,6 +83,7 @@ export type Config = {
   linked: Linked;
   access: AccessType;
   baseBranch: string;
+  alwaysOpenEditor: boolean;
   /** The minimum bump type to trigger automatic update of internal dependencies that are part of the same release */
   updateInternalDependencies: "patch" | "minor";
   ignore: ReadonlyArray<string>;
@@ -100,6 +101,7 @@ export type WrittenConfig = {
   linked?: Linked;
   access?: AccessType;
   baseBranch?: string;
+  alwaysOpenEditor: boolean;
   /** The minimum bump type to trigger automatic update of internal dependencies that are part of the same release */
   updateInternalDependencies?: "patch" | "minor";
   ignore?: ReadonlyArray<string>;

--- a/packages/types/src/index.ts
+++ b/packages/types/src/index.ts
@@ -84,6 +84,7 @@ export type Config = {
   access: AccessType;
   baseBranch: string;
   alwaysOpenEditor: boolean;
+  shouldAskForChangeTypes: boolean;
   /** The minimum bump type to trigger automatic update of internal dependencies that are part of the same release */
   updateInternalDependencies: "patch" | "minor";
   ignore: ReadonlyArray<string>;
@@ -102,6 +103,7 @@ export type WrittenConfig = {
   access?: AccessType;
   baseBranch?: string;
   alwaysOpenEditor: boolean;
+  shouldAskForChangeTypes: boolean;
   /** The minimum bump type to trigger automatic update of internal dependencies that are part of the same release */
   updateInternalDependencies?: "patch" | "minor";
   ignore?: ReadonlyArray<string>;

--- a/packages/types/src/index.ts
+++ b/packages/types/src/index.ts
@@ -13,7 +13,11 @@ export type DependencyType = typeof DEPENDENCY_TYPES[number];
 
 export type AccessType = "public" | "restricted";
 
-export type Release = { name: string; type: VersionType };
+export type Release = {
+  name: string;
+  type: VersionType;
+  changeTypes?: ChangeType[];
+};
 
 // This is a release that has been modified to include all relevant information
 // about releasing - it is calculated and doesn't make sense as an artefact
@@ -28,6 +32,17 @@ export type ComprehensiveRelease = {
 export type Changeset = {
   summary: string;
   releases: Array<Release>;
+};
+
+export type EmptyString = ``;
+
+export type ChangeType = {
+  category: string;
+  description: string;
+};
+
+export type ChangesetWithConfirmed = Changeset & {
+  confirmed: boolean;
 };
 
 export type NewChangeset = Changeset & {

--- a/packages/write/src/index.ts
+++ b/packages/write/src/index.ts
@@ -3,7 +3,8 @@ import path from "path";
 import prettier from "prettier";
 import humanId from "human-id";
 import { Changeset } from "@changesets/types";
-import { getChangesetContent } from "../../cli/src/commands/add/changeTypes";
+// @TODO update import to use modules
+import { getChangesetContent } from "../../cli/src/commands/add/writeChangeTypes";
 
 async function writeChangeset(
   changeset: Changeset,

--- a/packages/write/src/index.ts
+++ b/packages/write/src/index.ts
@@ -3,6 +3,7 @@ import path from "path";
 import prettier from "prettier";
 import humanId from "human-id";
 import { Changeset } from "@changesets/types";
+import { getChangesetContent } from "../../cli/src/commands/add/changeTypes";
 
 async function writeChangeset(
   changeset: Changeset,
@@ -23,10 +24,17 @@ async function writeChangeset(
 
   const newChangesetPath = path.resolve(changesetBase, `${changesetID}.md`);
 
+  const releasesGroupedByBumpTypes = getChangesetContent(
+    releases,
+    summary,
+    true
+  );
   // NOTE: The quotation marks in here are really important even though they are
   // not spec for yaml. This is because package names can contain special
   // characters that will otherwise break the parsing step
-  const changesetContents = `---
+  const changesetContents =
+    releasesGroupedByBumpTypes ||
+    `---
 ${releases.map(release => `"${release.name}": ${release.type}`).join("\n")}
 ---
 

--- a/packages/write/src/index.ts
+++ b/packages/write/src/index.ts
@@ -24,11 +24,7 @@ async function writeChangeset(
 
   const newChangesetPath = path.resolve(changesetBase, `${changesetID}.md`);
 
-  const releasesGroupedByBumpTypes = getChangesetContent(
-    releases,
-    summary,
-    true
-  );
+  const releasesGroupedByBumpTypes = getChangesetContent(releases, summary);
   // NOTE: The quotation marks in here are really important even though they are
   // not spec for yaml. This is because package names can contain special
   // characters that will otherwise break the parsing step

--- a/packages/write/src/index.ts
+++ b/packages/write/src/index.ts
@@ -24,7 +24,12 @@ async function writeChangeset(
 
   const newChangesetPath = path.resolve(changesetBase, `${changesetID}.md`);
 
-  const releasesGroupedByBumpTypes = getChangesetContent(releases, summary);
+  const shouldSplitReleasesByBumpType = true;
+  const releasesGroupedByBumpTypes = getChangesetContent(
+    releases,
+    summary,
+    shouldSplitReleasesByBumpType
+  );
   // NOTE: The quotation marks in here are really important even though they are
   // not spec for yaml. This is because package names can contain special
   // characters that will otherwise break the parsing step


### PR DESCRIPTION
Separate PR for requirements from follow-up letter (alwaysOpenEditor config flag, UX change type)

Has all the changes from [PR1](https://github.com/atlassian-forks/changesets/pull/1) + alwaysOpenEditor and UX change type.

As requested by [rohan-deshpande](https://github.com/atlassian-forks/changesets/pull/1#issuecomment-1127111747)