### PR TITLE
None changeset

### DIFF
--- a/packages/assemble-release-plan/src/determine-dependents.ts
+++ b/packages/assemble-release-plan/src/determine-dependents.ts
@@ -128,9 +128,6 @@ export default function determineDependents({
       .forEach(
         // @ts-ignore - I don't know how to make typescript understand that the filter above guarantees this and I got sick of trying
         ({ name, type, pkgJSON }: Release & { pkgJSON: PackageJSON }) => {
-          // At this point, we know if we are making a change
-          updated = true;
-
           const existing = releases.get(name);
           // For things that are being given a major bump, we check if we have already
           // added them here. If we have, we update the existing item instead of pushing it on to search.
@@ -141,16 +138,20 @@ export default function determineDependents({
             existing.type = "major";
 
             pkgsToSearch.push(existing);
+            updated = true; // At this point, we know if we are making a change
           } else {
-            let newDependent: InternalRelease = {
-              name,
-              type,
-              oldVersion: pkgJSON.version,
-              changesets: []
-            };
+            if (nextRelease.type !== "none") {
+              let newDependent: InternalRelease = {
+                name,
+                type,
+                oldVersion: pkgJSON.version,
+                changesets: []
+              };
 
-            pkgsToSearch.push(newDependent);
-            releases.set(name, newDependent);
+              pkgsToSearch.push(newDependent);
+              releases.set(name, newDependent);
+              updated = true; // At this point, we know if we are making a change
+            }
           }
         }
       );

--- a/packages/cli/src/commands/add/__tests__/add.ts
+++ b/packages/cli/src/commands/add/__tests__/add.ts
@@ -36,18 +36,22 @@ const mockUserResponses = mockResponses => {
   const summary = mockResponses.summary || "summary message mock";
   let majorReleases: Array<string> = [];
   let minorReleases: Array<string> = [];
+  let patchReleases: Array<string> = [];
   Object.entries(mockResponses.releases).forEach(([pkgName, type]) => {
     if (type === "major") {
       majorReleases.push(pkgName);
     } else if (type === "minor") {
       minorReleases.push(pkgName);
+    } else if (type === "patch") {
+      patchReleases.push(pkgName);
     }
   });
   let callCount = 0;
   let returnValues = [
     Object.keys(mockResponses.releases),
     majorReleases,
-    minorReleases
+    minorReleases,
+    patchReleases
   ];
   // @ts-ignore
   askCheckboxPlus.mockImplementation(() => {

--- a/packages/cli/src/commands/add/__tests__/add.ts
+++ b/packages/cli/src/commands/add/__tests__/add.ts
@@ -208,4 +208,20 @@ describe("Changesets", () => {
       })
     );
   });
+
+  it("should generate a none changeset for a single package", async () => {
+    const cwd = await f.copy("simple-project");
+
+    mockUserResponses({ releases: { "pkg-a": "none" } });
+    await addChangeset(cwd, { empty: false }, defaultConfig);
+
+    // @ts-ignore
+    const call = writeChangeset.mock.calls[0][0];
+    expect(call).toEqual(
+      expect.objectContaining({
+        summary: "summary message mock",
+        releases: [{ name: "pkg-a", type: "none" }]
+      })
+    );
+  });
 });

--- a/packages/cli/src/commands/add/createChangeset.ts
+++ b/packages/cli/src/commands/add/createChangeset.ts
@@ -8,7 +8,7 @@ import { Release, PackageJSON, VersionType } from "@changesets/types";
 import { Package } from "@manypkg/get-packages";
 import { ExitError } from "@changesets/errors";
 
-const { green, yellow, red, bold, blue, cyan } = chalk;
+const { green, yellow, red, bold, blue, cyan, gray } = chalk;
 
 type PackageNameJsonMap = Map<string, PackageJSON>;
 
@@ -105,7 +105,8 @@ function getBumpTypeTitle(bumpType: VersionType) {
 const bumpTypes: { type: VersionType; title: VersionType }[] = [
   { type: "major", title: red("major") as VersionType },
   { type: "minor", title: green("minor") as VersionType },
-  { type: "patch", title: blue("patch") as VersionType }
+  { type: "patch", title: blue("patch") as VersionType },
+  { type: "none", title: gray("none") as VersionType }
 ];
 
 export async function choosePkgsForBumpType(

--- a/packages/cli/src/commands/add/createChangeset.ts
+++ b/packages/cli/src/commands/add/createChangeset.ts
@@ -174,6 +174,8 @@ export default async function createChangeset(
       const isLast = i === bumpTypes.length - 1;
       let pkgsForThisBumpType: string[] = [];
 
+      if (!packages.length) break;
+
       if (isLast) {
         const bumpType = blue(bump.title) as VersionType;
         logRestWillBeBumped(bumpType, packages, pkgJsonsByName);

--- a/packages/cli/src/commands/version/version.test.ts
+++ b/packages/cli/src/commands/version/version.test.ts
@@ -67,6 +67,12 @@ const simpleChangeset3: NewChangeset = {
   id: "hot-day-today"
 };
 
+const simpleNoneChangeset: NewChangeset = {
+  summary: "Is this a summary?",
+  releases: [{ name: "pkg-a", type: "none" }],
+  id: "cake-is-lie"
+};
+
 const writeChangesets = (changesets: NewChangeset[], cwd: string) => {
   return Promise.all(
     changesets.map(changeset => writeChangeset(changeset, cwd))
@@ -301,6 +307,18 @@ describe("running version in a simple project", () => {
         },
       ]
     `);
+  });
+
+  it("should skip none changesets", async () => {
+    let cwd = f.copy("simple-project");
+    await writeChangesets([simpleNoneChangeset], cwd);
+    const spy = jest.spyOn(fs, "writeFile");
+
+    await version(cwd, defaultOptions, modifiedDefaultConfig);
+
+    expect(getPkgJSON("pkg-a", spy.mock.calls)).toEqual(
+      expect.objectContaining({ name: "pkg-a", version: "1.0.0" })
+    );
   });
 
   describe("when there are multiple changeset commits", () => {

--- a/packages/config/src/index.ts
+++ b/packages/config/src/index.ts
@@ -78,7 +78,7 @@ const havePackageGroupsCorrectShape = (
   );
 };
 
-// TODO:  it might be possible to remove this if improvements to `Array.isArray` ever land
+// TODO: it might be possible to remove this if improvements to `Array.isArray` ever land
 // related thread: github.com/microsoft/TypeScript/issues/36554
 function isArray<T>(
   arg: T | {}

--- a/packages/config/src/index.ts
+++ b/packages/config/src/index.ts
@@ -78,7 +78,7 @@ const havePackageGroupsCorrectShape = (
   );
 };
 
-// TODO: it might be possible to remove this if improvements to `Array.isArray` ever land
+// TODO:  it might be possible to remove this if improvements to `Array.isArray` ever land
 // related thread: github.com/microsoft/TypeScript/issues/36554
 function isArray<T>(
   arg: T | {}


### PR DESCRIPTION
Add none changeset option alongside major, minor, and patch prompts

Ignore none changeset in a CHANGELOG.md file `yarn changeset version`