### PR TITLE
Allow `sinceRef` to work with non-root cwds

### DIFF
--- a/.changeset/eight-lies-carry.md
+++ b/.changeset/eight-lies-carry.md
@@ -2,4 +2,4 @@
 "@changesets/read": patch
 ---
 
-Fix a bug with changeset files not being read when using a non-root current working directory along with the `sinceRef` argument
+Fix a bug with changeset files not being read when a non-root current working directory is used along with the `sinceRef` argument

--- a/.changeset/eight-lies-carry.md
+++ b/.changeset/eight-lies-carry.md
@@ -1,0 +1,5 @@
+---
+"@changesets/read": patch
+---
+
+Fix a bug with changeset files not being read when using a non-root current working directory along with the `sinceRef` argument

--- a/packages/read/src/index.ts
+++ b/packages/read/src/index.ts
@@ -14,10 +14,10 @@ async function filterChangesetsSinceRef(
     cwd: changesetBase,
     ref: sinceRef
   });
-    
-  const newHashes = newChangesets.map(c => { 
-    const parts = c.split("/")
-    return parts[parts.length - 1]
+
+  const newHashes = newChangesets.map(c => {
+    const parts = c.split("/");
+    return parts[parts.length - 1];
   });
 
   return changesets.filter(dir => newHashes.includes(dir));

--- a/packages/read/src/index.ts
+++ b/packages/read/src/index.ts
@@ -14,7 +14,11 @@ async function filterChangesetsSinceRef(
     cwd: changesetBase,
     ref: sinceRef
   });
-  const newHashes = newChangesets.map(c => c.split("/")[1]);
+    
+  const newHashes = newChangesets.map(c => { 
+    const parts = c.split("/")
+    return parts[parts.length - 1]
+  });
 
   return changesets.filter(dir => newHashes.includes(dir));
 }


### PR DESCRIPTION
When `sinceRef` is used with a cwd that is not at the repository root, `newHashes` isn't calculated properly, resulting in valid changesets being filtered out in the read changesets response.

#### Details 
Let's say the changeset root was at `project/subfolder/.changeset`, and there was a changeset `some-changeset.md` present in this directory.

In `filterChangesetsSinceRef`, `newChangesets` would be — `['project/subfolder/.changeset/some-changeset.md']`.

https://github.com/atlassian-forks/changesets/blob/27a5a82188914570d192162f9d045dfd082a3c15/packages/read/src/index.ts#L13-L19

But since `newHashes` incorrectly always takes the second half of a string split by `/`, it would result in `newHashes` being `subfolder` instead of `some-changeset.md`.

Instead, its safer to peek at the last part of the path fragment (which would always refer to the file).